### PR TITLE
Added downloaded file size control at fetch time to show actual error

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -28,6 +28,14 @@ fetch() {
   if [ ! -f /tars/$api_tar ]; then
     curl -L -o /tars/$api_tar $api_url
   fi
+  # Added download files size control
+  minsize=100000
+  size_client=$(stat -c%s /tars/"$client_tar")
+  size_api=$(stat -c%s /tars/"$api_tar")
+  if [ $size_client -lt $minsize ] || [ $size_api -lt $minsize ] ; then
+    echo "Error in downloaded file!"
+    exit 1
+  fi
 }
 
 build() {


### PR DESCRIPTION
When you put wrong values in build_env.sh a file of 30k is downloaded and then you get gzip error. 
After this change, script exit and show an error explaining that is a download error. 