### PR TITLE
Enable Apache headers mod

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -136,6 +136,7 @@ setup_apache() {
   cp /dist/apache-vhost.conf /etc/apache2/sites-available/000-default.conf
   ( cd /etc/apache2/sites-enabled ; ln -sf ../sites-available/000-default.conf . )
   ( cd /etc/apache2/mods-enabled ; ln -sf ../mods-available/rewrite.load . )
+  ( cd /etc/apache2/mods-enabled ; ln -sf ../mods-available/headers.load . )
   #
   cat > /etc/supervisor/conf.d/apache2 <<EOF
 [program:apache2]


### PR DESCRIPTION
This PR resolves an error emitted by Apache when the *platform-release* is installed exactly as stated in the README.
```
/var/www/html/.htaccess: Invalid command 'Header', perhaps misspelled or defined by a module not included in the server configuration
```

This is caused by `Header set X-XSS-Protection "1; mode=block"` used in aforementioned .htaccess file, for which Apache needs to have *mod_headers* module loaded. Also slightly related to PR #11 where the same headers are added to another config file. 