### PR TITLE
#28 aids to set up the release to work with the mobile app

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ This should be fairly doable with a variation of the nginx-proxy approach descri
 
 Contributions welcome!
 
+# Connecting the mobile app
+
+Please note that the mobile app relies on the contents of the config.json file in order to
+connect to the API backend.
+
+In order to help the app find the backend, ensure that the key `backend_url` in the
+JSON file is set appropriately to the absolute public URL of your deployment
+(i.e. `"backend_url": "https://example.deployment.com"` )
+
+If you are running the Docker container, you may set this variable using the
+`SITE_URL` environment variable. (In the default install the site URL **is** the backend URL).
+
 # Other documentation
 
 For other documentation, please check out our [Developer and Contributor docs](https://docs.ushahidi.com/platform-developer-documentation/) !

--- a/docker-compose.apache.yml
+++ b/docker-compose.apache.yml
@@ -16,6 +16,11 @@ services:
       MYSQL_DATABASE: ushahidi
       MYSQL_USER: ushahidi
       MYSQL_PASSWORD: ushahidi
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      CACHE_DRIVER: redis
+      # Setting this variable is required for the mobile app to work:
+      # SITE_URL: http://example.com
   mysql:
     image: mysql:5.7
     environment:
@@ -23,3 +28,5 @@ services:
       MYSQL_DATABASE: ushahidi
       MYSQL_USER: ushahidi
       MYSQL_PASSWORD: ushahidi
+  redis:
+    image: redis:4-alpine

--- a/docker-compose.tls.yml
+++ b/docker-compose.tls.yml
@@ -30,6 +30,8 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: "6379"
       CACHE_DRIVER: redis
+      # Setting this variable is required for the mobile app to work:
+      # SITE_URL: http://127.0.0.1.xip.io
   mysql:
     image: mysql:5.7
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: "6379"
       CACHE_DRIVER: redis
+      # Setting this variable is required for the mobile app to work:
+      # SITE_URL: http://example.com
   mysql:
     image: mysql:5.7
     environment:

--- a/run.sh
+++ b/run.sh
@@ -43,14 +43,32 @@ fetch() {
 
 gen_config_json() {
   local dir=$1
+
+  if [ -z "${SITE_URL}" ]; then
+    (
+      set +x
+      echo
+      echo "!!! MOBILE APP : Incomplete configuration !!!"
+      echo
+      echo "Please note that for the Ushahidi Mobile App to work with this"
+      echo "deployment, you will need to configure the SITE_URL environment"
+      echo "variable. You should provide the *absolute publicly available*"
+      echo "URL where you are publishing the site, i.e.:"
+      echo
+      echo "    docker run -e 'SITE_URL=https://site.example.com' ... ushahidi/platform-release:latest"
+      echo
+     ) >&2 ;
+    sleep 3;
+  fi
+
   cat > $dir/config.json <<EOF
 {
 "client_id": "ushahidiui",
 "client_secret": "35e7f0bca957836d05ca0492211b0ac707671261",
-"backend_url": "/",
+"backend_url": "${SITE_URL:-/}",
 "google_analytics_id": "",
 "intercom_app_id": "",
-"mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXRrbmF5MDdxNmZubmUyN2p6bms5biJ9.o7pmKDIN1EtwMBp1VIzITQ",
+"mapbox_api_key": "pk.eyJ1IjoidXNoYWhpZGkiLCJhIjoiY2lxaXUzeHBvMDdndmZ0bmVmOWoyMzN6NiJ9.CX56ZmZJv0aUsxvH5huJBw",
 "raven_url": ""
 }
 EOF


### PR DESCRIPTION
* Explains how config.json needs to point at the absolute backend URL
* Sets up the container to handle a `SITE_URL` variable to fill the config.json as necessary

Chores:
* Set the proper mapbox key
* Bring the docker-compose yml for apache up to date
