### PR TITLE
fix(nginx): complete list of paths to pass through to the api codebase

### DIFF
--- a/dist/nginx-site.conf
+++ b/dist/nginx-site.conf
@@ -13,7 +13,7 @@ server {
 	client_max_body_size 64M;
 
 	# /api and /oauth requests get passed to php-fpm
-	location ~ ^/(api)|(oauth) {
+	location ~ ^/(api)|(oauth)|(sms)|(frontlinesms)|(nexmo)|(smssync)|(plugin) {
 		alias /var/www/html/platform/httpdocs;
 
 		try_files $uri /index.php =404;

--- a/dist/nginx-site.conf
+++ b/dist/nginx-site.conf
@@ -13,7 +13,7 @@ server {
 	client_max_body_size 64M;
 
 	# /api and /oauth requests get passed to php-fpm
-	location ~ ^/(api)|(oauth)|(sms)|(frontlinesms)|(nexmo)|(smssync)|(plugin) {
+	location ~ ^/(api)|(oauth)|(sms)|(frontlinesms)|(nexmo)|(smssync)|(plugins) {
 		alias /var/www/html/platform/httpdocs;
 
 		try_files $uri /index.php =404;


### PR DESCRIPTION
We were missing a few important routes, especially for SMS data source integration.

I've added "plugin", which is not used now, but where we should be tucking in future data sources/extended functionality (as long as it makes sense).