### PR TITLE
Ush-1100 - If a user mounts their own filesystem into our docker container, it may destroy files in the folder

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -218,7 +218,7 @@ needs_install() {
 
 install_app() {
   # Install release folders in webroot
-  rsync -ar --delete-after ${release_target_folder}/html/ ${PLATFORM_HOME}/
+  rsync -ar ${release_target_folder}/html/ ${PLATFORM_HOME}/
   #
   ## Configure platform environment ensure mysql connection and run migrations
   #


### PR DESCRIPTION
In our setup of a new docker container, the run.sh script uses rsync to setup the filesystem for the backend. This was deleting files if a deployment had mounted an external file system where the uploads land, due to the inclusion of the --delete-after command parameter. 

https://linear.app/ushahidi/issue/USH-1100/docker-rebuild-command-delete-the-images-files